### PR TITLE
Refactored Shader Uniform Handling

### DIFF
--- a/.r3make/r3make
+++ b/.r3make/r3make
@@ -3,9 +3,6 @@
     "c-targets": {
         "r3": {
             "r3make": {
-                "pre-build": {
-                    "gitdeps": ["d34d0s/libx"]
-                },
                 "post-build": {
                     "nofiles": null
                 }
@@ -16,7 +13,7 @@
             "lib-links": {
                 "gdi32": null,
                 "opengl32": null,
-	    	    "libx": null
+	    	    "libx": "../external/libx/bin"
 	    },
             "out-type": "dll",
             "out-name": "r3",

--- a/demo/hello_triangle.c
+++ b/demo/hello_triangle.c
@@ -31,7 +31,8 @@ int main() {
         
     R3_Shader shader = r3_core->graphics.create_shader(
         filex->read("../engine/assets/shaders/default/shader.vert", 0),
-        filex->read("../engine/assets/shaders/default/shader.frag", 0));
+        filex->read("../engine/assets/shaders/default/shader.frag", 0)
+    );
 
     R3_Texture texture = r3_core->graphics.create_texture2D("../engine/assets/textures/logo.png", R3_RGBA_FORMAT);
     

--- a/engine/assets/shaders/light/shader.frag
+++ b/engine/assets/shaders/light/shader.frag
@@ -1,11 +1,41 @@
 #version 460 core
 
-in vec2 tex_coord;
+in vec3 normal;
+in vec3 fragment;
 
 out vec4 frag_color;
 
-uniform sampler2D u_texture;
+struct Material {
+    float shine;
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+};
+uniform Material u_material;
+
+struct Light {
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+    vec3 location;
+};
+uniform Light u_light;
+
+uniform vec3 u_view_location;
 
 void main() {
-    frag_color = texture(u_texture, tex_coord) * vec4(0, 0, 1, 1.0);
+    vec3 ambient = u_light.ambient * u_material.ambient;
+
+    vec3 norm = normalize(normal);
+    vec3 light_direction = normalize(u_light.location - fragment);
+    float diff = max(dot(norm, light_direction), 0.0);
+    vec3 diffuse = u_light.diffuse * (diff * u_material.diffuse);
+
+    vec3 view_direction = normalize(u_view_location - fragment);
+    vec3 reflection_direction = reflect(-light_direction, norm);
+    float spec = pow(max(dot(view_direction, reflection_direction), 0.0), u_material.shine);
+    vec3 specular = u_light.specular * (spec * u_material.specular);
+
+    vec3 result = ambient + diffuse + specular;
+    frag_color = vec4(result, 1.0);
 }

--- a/engine/assets/shaders/light/shader.vert
+++ b/engine/assets/shaders/light/shader.vert
@@ -1,7 +1,7 @@
 #version 460 core
 
 layout(location=0) in vec3 a_location;
-layout(location=1) in vec3 a_normal;
+layout(location=3) in vec3 a_normal;
 
 out vec3 normal;
 out vec3 fragment;
@@ -12,6 +12,6 @@ uniform mat4 u_proj;
 
 void main() {
     gl_Position = u_proj * u_view * u_model * vec4(a_location, 1);
-    fragment = vec3(u_model * vec4(a_location, 1));
+    fragment = mat3(u_model) * a_location;
     normal = a_normal;
 }

--- a/engine/assets/shaders/light/source.frag
+++ b/engine/assets/shaders/light/source.frag
@@ -1,0 +1,7 @@
+#version 460 core
+
+out vec4 frag_color;
+
+void main() {
+    frag_color = vec4(1.0);
+}

--- a/engine/assets/shaders/light/source.vert
+++ b/engine/assets/shaders/light/source.vert
@@ -1,10 +1,6 @@
 #version 460 core
 
 layout(location=0) in vec3 a_location;
-layout(location=1) in vec3 a_normal;
-
-out vec3 normal;
-out vec3 fragment;
 
 uniform mat4 u_model;
 uniform mat4 u_view;
@@ -12,6 +8,4 @@ uniform mat4 u_proj;
 
 void main() {
     gl_Position = u_proj * u_view * u_model * vec4(a_location, 1);
-    fragment = vec3(u_model * vec4(a_location, 1));
-    normal = a_normal;
 }

--- a/engine/r3.core/include/r3.graphics.h
+++ b/engine/r3.core/include/r3.graphics.h
@@ -36,6 +36,13 @@ typedef enum R3_Uniform_Type {
     R3_UNIFORM_TYPES
 } R3_Uniform_Type;
 
+typedef struct R3_Uniform {
+    void* value;
+    cstr name;
+    u32 type;
+    u32 location;
+} R3_Uniform;
+
 typedef struct R3_Shader {
     Hash_Array* uniforms;
     u32 program;
@@ -134,8 +141,8 @@ typedef struct _r3_graphics_api {
     R3_Shader (*create_shader)(cstr vertex, cstr fragment);
     void (*destroy_shader)(R3_Shader* shader);
 
-    u8 (*set_uniform)(R3_Shader* shader, str name, void* value);
-    u8 (*send_uniform)(R3_Shader* shader, R3_Uniform_Type type, str name);
+    u8 (*set_uniform)(R3_Shader* shader, R3_Uniform* uniform);
+    u8 (*send_uniform)(R3_Shader* shader, str name);
 
     R3_Vertex_Data (*create_vertex_data)(f32 *vertices, u32 vertexCount, u32 *indices, u32 indexCount, u8 attrs);
     void (*destroy_vertex_data)(R3_Vertex_Data *vertexData);

--- a/engine/r3.core/src/r3.graphics.c
+++ b/engine/r3.core/src/r3.graphics.c
@@ -268,6 +268,8 @@ void _flush_pipeline_impl(void) {
             _graphics_api->send_uniform(shader, R3_UNIFORM_MAT4, "u_proj");
             _graphics_api->send_uniform(shader, R3_UNIFORM_MAT4, "u_view");
             _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_view_location");
+
+            // TODO: abstract lighting uniform handling to the post-render pipeline
             _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.ambient");
             _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.diffuse");
             _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.specular");
@@ -306,7 +308,7 @@ u8 _init_pipeline_impl(R3_Render_Mode mode, R3_Shader* shader, Mat4 proj) {
     _graphics_api->pipeline.mode = mode;
     _graphics_api->pipeline.proj = proj;
     _graphics_api->pipeline.shader = shader;
-    _graphics_api->pipeline.clear_color = mathx->vec.vec4(60/255.0, 120/255.0, 210/255.0, 255/255.0);
+    _graphics_api->pipeline.clear_color = (Vec4){0.14, 0.16, 0.18, 1.0};
 
     _graphics_api->set_uniform(_graphics_api->pipeline.shader, "u_proj", &_graphics_api->pipeline.proj.m);
     _graphics_api->pipeline.init = LIBX_TRUE;

--- a/engine/r3.core/src/r3.graphics.c
+++ b/engine/r3.core/src/r3.graphics.c
@@ -82,6 +82,7 @@ u8 _send_uniform_impl(R3_Shader* shader, R3_Uniform_Type type, str name) {
         case R3_UNIFORM_MAT4: _graphics_api->gl.uniform_matrix4fv(location, 1, 0, value); break;
         default: break;
     }
+    _graphics_api->gl.use_program(0);
     return LIBX_TRUE;
 }
 
@@ -140,7 +141,7 @@ R3_Vertex_Data _create_vertex_data_impl(f32 *vertices, u32 vertexCount, u32 *ind
     }
 
     // configure vertex attributes
-    for (int i = 0; i < R3_VERTEX_ATTRIBS; i++) {
+    for (int i = 0; i < R3_VERTEX_ATTRIBS/2; i++) {
         if ((attrs & (1 << i)) != 0) {
             _graphics_api->gl.vertex_attrib_pointer(
                 i, 
@@ -266,6 +267,11 @@ void _flush_pipeline_impl(void) {
         } else {
             _graphics_api->send_uniform(shader, R3_UNIFORM_MAT4, "u_proj");
             _graphics_api->send_uniform(shader, R3_UNIFORM_MAT4, "u_view");
+            _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_view_location");
+            _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.ambient");
+            _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.diffuse");
+            _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.specular");
+            _graphics_api->send_uniform(shader, R3_UNIFORM_VEC3, "u_light.location");
         }
         
         if (call.model) {

--- a/engine/r3.core/src/r3.graphics.c
+++ b/engine/r3.core/src/r3.graphics.c
@@ -7,7 +7,7 @@ R3_Shader _create_shader_impl(cstr vertex, cstr fragment) {
     u32 link = 0;
     u32 compile = 0;
 
-    R3_Shader shader = {.uniforms=structx->create_hash_array(16)};
+    R3_Shader shader = {.uniforms=structx->create_hash_array(32)};
     if (!shader.uniforms) {
         // error: failed to allocate uniform hashmap!
         return (R3_Shader){0};

--- a/external/libx/include/libx_ecs.h
+++ b/external/libx/include/libx_ecs.h
@@ -7,7 +7,7 @@
 #define COMPONENT_MAX   (1 << 5)
 #define ENTITY_MAX      ((1 << 16) - 1)
 
-typedef struct _stdlibx_ecs_api {
+typedef struct _libx_ecs_api {
     struct entity_manager {
         u32* queue;
         u32* mask;
@@ -41,8 +41,8 @@ typedef struct _stdlibx_ecs_api {
     u8 (*rem_component)(u8 id, u32 entity);
     u8 (*get_component)(u8 id, u32 entity, void* component);
     
-} _stdlibx_ecs_api;
-extern _stdlibx_ecs_api* ecsx;
+} _libx_ecs_api;
+extern _libx_ecs_api* ecsx;
 
 LIBX_API u8 libx_init_ecs(void);
 LIBX_API void libx_cleanup_ecs(void);

--- a/external/libx/include/libx_structs.h
+++ b/external/libx/include/libx_structs.h
@@ -98,6 +98,22 @@ typedef struct _libx_structs_api {
     Hash_Array* (*create_hash_array)(u32 max);
     u8 (*put_hash_array)(Hash_Array* array, cstr key, void* value);
     void* (*get_hash_array)(Hash_Array* array, cstr key);
+    
+    /**
+     * `get_hash_array_keys` iterates a given `Hash_Array` and populates a heap-allocated array
+     * containing all the keys stored in the `Hash_Array`.
+     * 
+     * Note: Don't forget to call `structx->destroy_array()` on the array returned from `get_hash_array_keys` when no longer needed!
+     */
+    cstr* (*get_hash_array_keys)(Hash_Array* array);
+    
+    /**
+     * `get_hash_array_values` iterates a given `Hash_Array` and populates a heap-allocated array
+     * containing all the values stored in the `Hash_Array`.
+     * 
+     * Note: Don't forget to call `structx->destroy_array()` on the array returned from `get_hash_array_values` when no longer needed!
+     */
+    void** (*get_hash_array_values)(Hash_Array* array);
     u8 (*pull_hash_array)(Hash_Array* array, cstr key, Key_Value* out);
     void (*destroy_hash_array)(Hash_Array* array);
 } _libx_structs_api;


### PR DESCRIPTION
## Changes
- implemented automatic shader uniform handling within `_r3_graphics_api::flush_pipeline` utilizing `libx` `Hash_Array` iterators.
- implemented `R3_Uniform` structure for storage within `R3_Shader::uniforms` `Hash_Array` field.
- implemented phong-model lighting shaders in `engine/assets/shaders/light` (source/shader.vert, sourceshader.frag)