### PR TITLE
r3.3D

### DIFF
--- a/examples/hello_3D.c
+++ b/examples/hello_3D.c
@@ -57,11 +57,6 @@ int main() {
         filex->read("assets/shaders/light/shader.vert", 0),
         filex->read("assets/shaders/light/shader.frag", 0)
     );
-    
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.ambient", .value = &u_light.ambient});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.diffuse", .value = &u_light.diffuse});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.specular", .value = &u_light.specular});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.location", .value = &u_light.location});
 
     R3_Texture texture = r3_core->graphics.create_texture2D("assets/textures/logo.png", R3_RGBA_FORMAT);
     
@@ -78,14 +73,8 @@ int main() {
     R3_Mesh3D mesh0; ecsx->get_component(R3_MESH3D, entity0, &mesh0);
     *mesh0.texture = texture;
 
-    R3_Material3D mat0; ecsx->get_component(R3_MATERIAL3D, entity0, &mat0);
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_FLOAT, .name = "u_material.shine", .value = mat0.shine});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.ambient", .value = mat0.ambient});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.diffuse", .value = mat0.diffuse});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.specular", .value = mat0.specular});
-
     R3_Transform3D trans0; ecsx->get_component(R3_TRANSFORM3D, entity0, &trans0);
-    *trans0.scale = (Vec3){64, 64, 64};
+    *trans0.scale = (Vec3){10, 10, 10};
 
     R3_Mesh3D mesh1; ecsx->get_component(R3_MESH3D, entity1, &mesh1);
     *mesh1.texture = texture;
@@ -97,7 +86,13 @@ int main() {
     ));
 
     R3_Transform3D trans1; ecsx->get_component(R3_TRANSFORM3D, entity1, &trans1);
-    *trans1.scale = (Vec3){64, 64, 64};
+    *trans1.location = mathx->vec.vec3(0, 0, -32);
+    *trans1.scale = (Vec3){5, 5, 5};
+    
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.ambient", .value = &u_light.ambient});
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.diffuse", .value = &u_light.diffuse});
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.specular", .value = &u_light.specular});
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.location", .value = trans1.location});
 
     r3_core->graphics.init_pipeline(
         R3_TRIANGLE_MODE, &shader,
@@ -120,9 +115,8 @@ int main() {
         mesh0.color->x = LIBX_CLAMP(mesh0.color->x + (0.01 * (r3_core->input.key_is_down(R3_KEY_PLUS) - r3_core->input.key_is_down(R3_KEY_MINUS))), 0.0, 1.0);
         r3_core->graphics.toggle_wireframe(r3_core->input.key_is_down(R3_KEY_F1));
 
-        u_light.location.x += 1.0 * (r3_core->input.key_is_down(R3_KEY_RIGHT) - r3_core->input.key_is_down(R3_KEY_LEFT));
-        u_light.location.y += 1.0 * (r3_core->input.key_is_down(R3_KEY_UP) - r3_core->input.key_is_down(R3_KEY_DOWN));
-        *trans1.location = u_light.location;
+        trans1.location->x += 1.0 * (r3_core->input.key_is_down(R3_KEY_RIGHT) - r3_core->input.key_is_down(R3_KEY_LEFT));
+        trans1.location->y += 1.0 * (r3_core->input.key_is_down(R3_KEY_UP) - r3_core->input.key_is_down(R3_KEY_DOWN));
         
         r3_core->graphics.translate_camera(
             (r3_core->input.key_is_down(R3_KEY_D) - r3_core->input.key_is_down(R3_KEY_A)),
@@ -131,7 +125,7 @@ int main() {
         );
 
         ecsx->run_systems(R3_TRANSFORM3D);
-        // ecsx->run_systems(R3_MATERIAL3D);    // TODO: figure out the shader pointer error?
+        ecsx->run_systems(R3_MATERIAL3D);
         ecsx->run_systems(R3_MESH3D);
 
         r3_core->graphics.update_camera();

--- a/examples/hello_3D.c
+++ b/examples/hello_3D.c
@@ -1,4 +1,7 @@
-#define R3_MODULES R3_CORE
+// hello_3D.c
+// Now fully driven by libx ecsx!
+
+#define R3_MODULES R3_CORE|R3_3D
 #include <r3/r3.core/include/r3.core.h>
 
 u8 running = 1;
@@ -29,7 +32,7 @@ u8 camera_callback(u16 event_code, R3_Event data) {
 int main() {
     r3_init_core(R3_MODULES);
         
-    R3_Window* window = r3_core->platform.create_window("Hello Cube", 800, 600);
+    R3_Window* window = r3_core->platform.create_window("Hello 3D", 800, 600);
     r3_core->platform.create_gl_context();
     r3_core->graphics.init_gl(&r3_core->graphics);
     
@@ -50,18 +53,6 @@ int main() {
         .location = mathx->vec.vec3(-2, 0.0, -2*32)
     };
     
-    struct Material {
-        f32 shine;
-        Vec3 ambient;
-        Vec3 diffuse;
-        Vec3 specular;
-    } u_material = {
-        .shine = 32.0,
-        .ambient = mathx->vec.vec3(1.0, 0.5, 0.31),
-        .diffuse = mathx->vec.vec3(1.0, 0.5, 0.31),
-        .specular = mathx->vec.vec3(0.5, 0.5, 0.5)
-    };
-    
     R3_Shader shader = r3_core->graphics.create_shader(
         filex->read("assets/shaders/light/shader.vert", 0),
         filex->read("assets/shaders/light/shader.frag", 0)
@@ -72,70 +63,41 @@ int main() {
     r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.specular", .value = &u_light.specular});
     r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_light.location", .value = &u_light.location});
 
-    // TODO: debug why this float uniform types appear to not be set properly
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_FLOAT, .name = "u_material.shine", .value = &u_material.shine});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.ambient", .value = &u_material.ambient});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.diffuse", .value = &u_material.diffuse});
-    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.specular", .value = &u_material.specular});
-
-    R3_Shader shader2 = r3_core->graphics.create_shader(
-        filex->read("assets/shaders/light/source.vert", 0),
-        filex->read("assets/shaders/light/source.frag", 0)
-    );
-
     R3_Texture texture = r3_core->graphics.create_texture2D("assets/textures/logo.png", R3_RGBA_FORMAT);
     
-    f32 speed = 0.5;
-    f32 rotation = 0.0;
-    Mat4 u_model = mathx->mat.identity4();
-    Vec3 location = mathx->vec.vec3(0, 0, 0);
-    R3_Vertex_Data vertex_data = r3_core->graphics.create_vertex_data(
-        (f32[]){
-            -0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f,
-             0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f, 
-             0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f, 
-             0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f, 
-            -0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f, 
-            -0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f, 
-        
-            -0.5f, -0.5f,  0.5f,  0.0f,  0.0f, 1.0f,
-             0.5f, -0.5f,  0.5f,  0.0f,  0.0f, 1.0f,
-             0.5f,  0.5f,  0.5f,  0.0f,  0.0f, 1.0f,
-             0.5f,  0.5f,  0.5f,  0.0f,  0.0f, 1.0f,
-            -0.5f,  0.5f,  0.5f,  0.0f,  0.0f, 1.0f,
-            -0.5f, -0.5f,  0.5f,  0.0f,  0.0f, 1.0f,
-        
-            -0.5f,  0.5f,  0.5f, -1.0f,  0.0f,  0.0f,
-            -0.5f,  0.5f, -0.5f, -1.0f,  0.0f,  0.0f,
-            -0.5f, -0.5f, -0.5f, -1.0f,  0.0f,  0.0f,
-            -0.5f, -0.5f, -0.5f, -1.0f,  0.0f,  0.0f,
-            -0.5f, -0.5f,  0.5f, -1.0f,  0.0f,  0.0f,
-            -0.5f,  0.5f,  0.5f, -1.0f,  0.0f,  0.0f,
-        
-             0.5f,  0.5f,  0.5f,  1.0f,  0.0f,  0.0f,
-             0.5f,  0.5f, -0.5f,  1.0f,  0.0f,  0.0f,
-             0.5f, -0.5f, -0.5f,  1.0f,  0.0f,  0.0f,
-             0.5f, -0.5f, -0.5f,  1.0f,  0.0f,  0.0f,
-             0.5f, -0.5f,  0.5f,  1.0f,  0.0f,  0.0f,
-             0.5f,  0.5f,  0.5f,  1.0f,  0.0f,  0.0f,
-        
-            -0.5f, -0.5f, -0.5f,  0.0f, -1.0f,  0.0f,
-             0.5f, -0.5f, -0.5f,  0.0f, -1.0f,  0.0f,
-             0.5f, -0.5f,  0.5f,  0.0f, -1.0f,  0.0f,
-             0.5f, -0.5f,  0.5f,  0.0f, -1.0f,  0.0f,
-            -0.5f, -0.5f,  0.5f,  0.0f, -1.0f,  0.0f,
-            -0.5f, -0.5f, -0.5f,  0.0f, -1.0f,  0.0f,
-        
-            -0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f,
-             0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f,
-             0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,
-             0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,
-            -0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,
-            -0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f
-        }, 36, NULL, 0, R3_LOCATION_ATTR | R3_NORMAL_ATTR
-    );
+    u32 entity0 = ecsx->create_entity();
+    ecsx->add_component(R3_TRANSFORM3D, entity0);
+    ecsx->add_component(R3_MESH3D, entity0);
+    ecsx->add_component(R3_MATERIAL3D, entity0);
     
-    Mat4 u_model2 = mathx->mat.identity4();
+    u32 entity1 = ecsx->create_entity();
+    ecsx->add_component(R3_TRANSFORM3D, entity1);
+    ecsx->add_component(R3_MESH3D, entity1);
+    ecsx->add_component(R3_SHADER3D, entity1);
+
+    R3_Mesh3D mesh0; ecsx->get_component(R3_MESH3D, entity0, &mesh0);
+    *mesh0.texture = texture;
+
+    R3_Material3D mat0; ecsx->get_component(R3_MATERIAL3D, entity0, &mat0);
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_FLOAT, .name = "u_material.shine", .value = mat0.shine});
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.ambient", .value = mat0.ambient});
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.diffuse", .value = mat0.diffuse});
+    r3_core->graphics.set_uniform(&shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name = "u_material.specular", .value = mat0.specular});
+
+    R3_Transform3D trans0; ecsx->get_component(R3_TRANSFORM3D, entity0, &trans0);
+    *trans0.scale = (Vec3){64, 64, 64};
+
+    R3_Mesh3D mesh1; ecsx->get_component(R3_MESH3D, entity1, &mesh1);
+    *mesh1.texture = texture;
+
+    r3_3D->set_shader3D(entity1, 
+        r3_core->graphics.create_shader(
+            filex->read("assets/shaders/light/source.vert", 0),
+            filex->read("assets/shaders/light/source.frag", 0)
+    ));
+
+    R3_Transform3D trans1; ecsx->get_component(R3_TRANSFORM3D, entity1, &trans1);
+    *trans1.scale = (Vec3){64, 64, 64};
 
     r3_core->graphics.init_pipeline(
         R3_TRIANGLE_MODE, &shader,
@@ -146,7 +108,7 @@ int main() {
         mathx->vec.vec3(0, 1, 0)
     );
     
-    r3_core->graphics.camera.speed = 0.5;
+    r3_core->graphics.camera.speed = 0.2;
     r3_core->graphics.camera.sensitivity = 0.05;
 
     r3_core->platform.hide_cursor();
@@ -155,35 +117,22 @@ int main() {
         r3_core->platform.poll_events();
         r3_core->platform.poll_inputs();
         
+        mesh0.color->x = LIBX_CLAMP(mesh0.color->x + (0.01 * (r3_core->input.key_is_down(R3_KEY_PLUS) - r3_core->input.key_is_down(R3_KEY_MINUS))), 0.0, 1.0);
         r3_core->graphics.toggle_wireframe(r3_core->input.key_is_down(R3_KEY_F1));
 
-        u_light.location.x += speed * (r3_core->input.key_is_down(R3_KEY_RIGHT) - r3_core->input.key_is_down(R3_KEY_LEFT));
-        u_light.location.y += speed * (r3_core->input.key_is_down(R3_KEY_UP) - r3_core->input.key_is_down(R3_KEY_DOWN));
+        u_light.location.x += 1.0 * (r3_core->input.key_is_down(R3_KEY_RIGHT) - r3_core->input.key_is_down(R3_KEY_LEFT));
+        u_light.location.y += 1.0 * (r3_core->input.key_is_down(R3_KEY_UP) - r3_core->input.key_is_down(R3_KEY_DOWN));
+        *trans1.location = u_light.location;
         
         r3_core->graphics.translate_camera(
             (r3_core->input.key_is_down(R3_KEY_D) - r3_core->input.key_is_down(R3_KEY_A)),
             (r3_core->input.key_is_down(R3_KEY_SPACE) - r3_core->input.key_is_down(R3_KEY_SHIFT)),
             (r3_core->input.key_is_down(R3_KEY_W) - r3_core->input.key_is_down(R3_KEY_S))
         );
-        
-        u_model = mathx->mat.identity4();
-        u_model = mathx->mat.mult4(u_model, mathx->mat.scale4(32, 32, 32));
-        u_model = mathx->mat.mult4(u_model, mathx->mat.trans4(location.x, location.y, location.z));
-        
-        u_model2 = mathx->mat.identity4();
-        u_model2 = mathx->mat.mult4(u_model2, mathx->mat.scale4(32, 32, 32));
-        u_model2 = mathx->mat.mult4(u_model2, mathx->mat.trans4(u_light.location.x, u_light.location.y, u_light.location.z));
-        
-        r3_core->graphics.push_pipeline(&(R3_Render_Call){
-            .vertex = &vertex_data, .model = &u_model,
-            .shader = NULL, .texture = &texture,
-            .mode = R3_TRIANGLE_MODE, .type = R3_RENDER_ARRAYS
-        });
-        r3_core->graphics.push_pipeline(&(R3_Render_Call){
-            .vertex = &vertex_data, .model = &u_model2,
-            .shader = &shader2, .texture = &texture,
-            .mode = R3_TRIANGLE_MODE, .type = R3_RENDER_ARRAYS
-        });
+
+        ecsx->run_systems(R3_TRANSFORM3D);
+        // ecsx->run_systems(R3_MATERIAL3D);    // TODO: figure out the shader pointer error?
+        ecsx->run_systems(R3_MESH3D);
 
         r3_core->graphics.update_camera();
         r3_core->graphics.flush_pipeline();

--- a/r3/r3.2D/src/component2D.c
+++ b/r3/r3.2D/src/component2D.c
@@ -18,6 +18,7 @@ static struct R3_Transform_Storage {
     Vec2 location[ENTITY_MAX];
 } transform_store = {0};
 
+
 u8 _add_sprite_impl(u32 entity) {
     sprite_store.size[entity] = (Vec2){32.0, 32.0};
     sprite_store.color[entity] = (Vec3){84/255.0, 52/255.0, 150/255.0};

--- a/r3/r3.2D/src/shape2D.c
+++ b/r3/r3.2D/src/shape2D.c
@@ -34,6 +34,7 @@ R3_Vertex_Data _quad2D_impl(Vec2 size, Vec3 color) {
     );
 }
 
+
 u8 _r3_init_shape2D(_r3_2D_api* r3_2D) {
     if (!r3_2D) return LIBX_FALSE;  // error: null ptr!
     

--- a/r3/r3.3D/include/component3D.h
+++ b/r3/r3.3D/include/component3D.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <r3/r3.core/include/r3.core.h>
+
+typedef enum R3_Component3D {
+    R3_MESH3D,
+    R3_TRANSFORM3D,
+    R3_MATERIAL3D,
+    R3_SHADER3D,
+    R3_COMPONENT3D_COUNT
+} R3_Component3D;
+
+typedef struct R3_Mesh3D {
+    Vec3* size;
+    Vec3* color;                 // passed as a per-call uniform (`u_sprite_color`) to the render pipeline;.
+    R3_Texture* texture;
+    R3_Vertex_Data* vertex;
+} R3_Mesh3D;
+
+typedef struct R3_Transform3D {
+    f32* speed;
+    Mat4* model;                // passed per-call to the render pipeline, and set as the value of the uniform (`u_model`).
+    Vec3* scale;
+    Vec3* rotation;
+    Vec3* velocity;
+    Vec3* location;
+} R3_Transform3D;
+
+typedef struct R3_Material3D {
+    f32* shine;
+    Vec3* ambient;
+    Vec3* diffuse;
+    Vec3* specular;
+} R3_Material3D;

--- a/r3/r3.3D/include/r3.3D.h
+++ b/r3/r3.3D/include/r3.3D.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <r3/r3.core/include/r3.core.h>
+#include <r3/r3.3D/include/component3D.h>
+
+typedef struct _r3_3D_api {
+    struct shape3D {
+        R3_Vertex_Data (*cube3D)(Vec3 size, Vec3 color);
+    } shape3D;
+    u8 (*set_shader3D)(u32 entity, R3_Shader shader);
+} _r3_3D_api;
+extern _r3_3D_api* r3_3D;
+
+// called internally via `r3_init_3D`
+u8 _r3_init_shape3D(_r3_3D_api* r3_3D);
+u8 _r3_register_component3D(_r3_3D_api* r3_3D);
+u8 _r3_unregister_component3D(void);
+
+// called internally via `r3_init_core`
+u8 r3_init_3D(void);
+// called internally via `r3_cleanup_core`
+u8 r3_cleanup_3D(void);

--- a/r3/r3.3D/src/component3D.c
+++ b/r3/r3.3D/src/component3D.c
@@ -1,0 +1,261 @@
+#include <r3/r3.3D/include/r3.3D.h>
+
+static Mat4 identity;
+
+static struct R3_Mesh_Storage {
+    Vec3 size[ENTITY_MAX];
+    Vec3 color[ENTITY_MAX];                 // u_mesh_color;
+    R3_Texture texture[ENTITY_MAX];
+    R3_Vertex_Data vertex[ENTITY_MAX];
+} mesh_store = {0};
+
+static struct R3_Transform_Storage {
+    f32 speed[ENTITY_MAX];
+    Mat4 model[ENTITY_MAX];
+    Vec3 scale[ENTITY_MAX];
+    Vec3 rotation[ENTITY_MAX];
+    Vec3 velocity[ENTITY_MAX];
+    Vec3 location[ENTITY_MAX];
+} transform_store = {0};
+
+static struct R3_Material_Storage {
+    f32 shine[ENTITY_MAX];
+    Vec3 ambient[ENTITY_MAX];
+    Vec3 diffuse[ENTITY_MAX];
+    Vec3 specular[ENTITY_MAX];
+} material_store = {0};
+
+static struct R3_ShaderSrc_Storage {
+    R3_Shader shader[ENTITY_MAX];
+} shader_store = {0};
+
+
+u8 _add_mesh3D_impl(u32 entity) {
+    mesh_store.size[entity] = mathx->vec.vec3(32.0, 32.0, 32.0);
+    mesh_store.texture[entity] = (R3_Texture){.id = 0};
+    mesh_store.color[entity] = mathx->vec.vec3(84/255.0, 52/255.0, 150/255.0);
+    mesh_store.vertex[entity] = r3_3D->shape3D.cube3D(mesh_store.size[entity], mesh_store.color[entity]);
+    return LIBX_TRUE;
+}
+
+u8 _rem_mesh3D_impl(u32 entity) {
+    mesh_store.size[entity] = (Vec3){0};
+    mesh_store.color[entity] = (Vec3){0};
+    mesh_store.texture[entity] = (R3_Texture){0};
+    mesh_store.vertex[entity] = (R3_Vertex_Data){0};
+    return LIBX_TRUE;
+}
+
+u8 _get_mesh3D_impl(u32 entity, R3_Mesh3D* component) {
+    component->size = &mesh_store.size[entity];
+    component->color = &mesh_store.color[entity];
+    component->texture = &mesh_store.texture[entity];
+    component->vertex = &mesh_store.vertex[entity];
+    return LIBX_TRUE;
+}
+
+u8 _mesh3D_system_impl(u32 entity) {
+    r3_core->graphics.push_pipeline(&(R3_Render_Call){
+        .mode = R3_TRIANGLE_MODE,
+        .vertex = &mesh_store.vertex[entity],
+        .type = (mesh_store.vertex[entity].indexCount) ? R3_RENDER_ELEMENTS : R3_RENDER_ARRAYS,
+        .model = (ecsx->has_component(R3_TRANSFORM3D, entity)) ? &transform_store.model[entity] : &identity,
+        .shader = (ecsx->has_component(R3_SHADER3D, entity) && shader_store.shader[entity].program) ? &shader_store.shader[entity] : NULL,
+        .texture = (mesh_store.texture[entity].id) ? &mesh_store.texture[entity] : NULL,
+        .uniform_count = 1, .uniforms = {
+            (R3_Uniform){
+                .name = "u_mesh_color",
+                .type = R3_UNIFORM_VEC3,
+                .value = &mesh_store.color[entity]
+            }
+        }
+    });
+
+    return LIBX_TRUE;
+}
+
+
+u8 _add_transform3D_impl(u32 entity) {
+    transform_store.speed[entity] = 10.0;
+    transform_store.model[entity] = mathx->mat.identity4();
+    transform_store.scale[entity] = mathx->vec.vec3(1, 1, 1);
+    transform_store.rotation[entity] = mathx->vec.vec3(0, 0, 0);
+    transform_store.velocity[entity] = mathx->vec.vec3(0, 0, 0);
+    transform_store.location[entity] = mathx->vec.vec3(0, 0, 0);
+    return LIBX_TRUE;
+}
+
+u8 _rem_transform3D_impl(u32 entity) {
+    transform_store.speed[entity] = 0.0;
+    transform_store.model[entity] = (Mat4){0};
+    transform_store.scale[entity] = (Vec3){0, 0, 0};
+    transform_store.rotation[entity] = (Vec3){0, 0, 0};
+    transform_store.velocity[entity] = (Vec3){0, 0, 0};
+    transform_store.location[entity] = (Vec3){0, 0, 0};
+    return LIBX_TRUE;
+}
+
+u8 _get_transform3D_impl(u32 entity, R3_Transform3D* component) {
+    component->speed = &transform_store.speed[entity];
+    component->model = &transform_store.model[entity];
+    component->scale = &transform_store.scale[entity];
+    component->rotation = &transform_store.rotation[entity];
+    component->velocity = &transform_store.velocity[entity];
+    component->location = &transform_store.location[entity];
+    return LIBX_TRUE;
+}
+
+u8 _transform3D_system_impl(u32 entity) {
+    transform_store.velocity[entity] = mathx->vec.scale3(
+        transform_store.velocity[entity],
+        transform_store.speed[entity]
+    );
+
+    transform_store.location[entity] = mathx->vec.add3(
+        transform_store.location[entity],
+        transform_store.velocity[entity]
+    );
+
+    transform_store.model[entity] = mathx->mat.identity4();
+    transform_store.model[entity] = mathx->mat.mult4(
+        transform_store.model[entity],
+        mathx->mat.scale4(
+            transform_store.scale[entity].x,
+            transform_store.scale[entity].y,
+            transform_store.scale[entity].z
+    ));
+
+    transform_store.model[entity] = mathx->mat.mult4(
+        transform_store.model[entity],
+        mathx->mat.rotx4(transform_store.rotation[entity].x)
+    );
+    transform_store.model[entity] = mathx->mat.mult4(
+        transform_store.model[entity],
+        mathx->mat.roty4(transform_store.rotation[entity].y)
+    );
+    transform_store.model[entity] = mathx->mat.mult4(
+        transform_store.model[entity],
+        mathx->mat.rotz4(transform_store.rotation[entity].z)
+    );
+    
+    transform_store.model[entity] = mathx->mat.mult4(
+        transform_store.model[entity],
+        mathx->mat.trans4(
+            transform_store.location[entity].x,
+            transform_store.location[entity].y,
+            transform_store.location[entity].z
+    ));
+
+    return LIBX_TRUE;
+}
+
+
+u8 _add_material3D_impl(u32 entity) {
+    material_store.shine[entity] = 32.0;
+    material_store.ambient[entity] = mathx->vec.vec3(1.0, 0.5, 0.31);
+    material_store.diffuse[entity] = mathx->vec.vec3(1.0, 0.5, 0.31);
+    material_store.specular[entity] = mathx->vec.vec3(0.5, 0.5, 0.5);
+    return LIBX_TRUE;
+}
+
+u8 _rem_material3D_impl(u32 entity) {
+    material_store.shine[entity] = 0.0;
+    material_store.ambient[entity] = (Vec3){0, 0, 0};
+    material_store.diffuse[entity] = (Vec3){0, 0, 0};
+    material_store.specular[entity] = (Vec3){0, 0, 0};
+    return LIBX_TRUE;
+}
+
+u8 _get_material3D_impl(u32 entity, R3_Material3D* component) {
+    component->shine = &material_store.shine[entity];
+    component->ambient = &material_store.ambient[entity];
+    component->diffuse = &material_store.diffuse[entity];
+    component->specular = &material_store.specular[entity];
+    return LIBX_TRUE;
+}
+
+u8 _material3D_system_impl(u32 entity) {
+    R3_Shader* shader = (ecsx->has_component(R3_SHADER3D, entity)) ? &shader_store.shader[entity] : r3_core->graphics.pipeline.shader;
+    r3_core->graphics.set_uniform(shader, &(R3_Uniform){.type = R3_UNIFORM_FLOAT,.name =  "u_material.shine",   .value = &material_store.shine[entity]});
+    r3_core->graphics.set_uniform(shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name =  "u_material.ambient", .value = &material_store.ambient[entity]});
+    r3_core->graphics.set_uniform(shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name =  "u_material.diffuse", .value = &material_store.diffuse[entity]});
+    r3_core->graphics.set_uniform(shader, &(R3_Uniform){.type = R3_UNIFORM_VEC3, .name =  "u_material.specular",.value = &material_store.specular[entity]});
+    return LIBX_TRUE;
+}
+
+
+u8 _add_shader3D_impl(u32 entity) {
+    shader_store.shader[entity] = (R3_Shader){0};
+}
+
+u8 _set_shader3D_impl(u32 entity, R3_Shader shader) {
+    if (!ecsx->has_component(R3_SHADER3D, entity)) return LIBX_FALSE;   // error: entity does not have component!
+    if (!shader.program) return LIBX_FALSE; // error: invalid shader passed!
+    shader_store.shader[entity] = shader;
+    return LIBX_TRUE;
+}
+
+u8 _rem_shader3D_impl(u32 entity) {
+    r3_core->graphics.destroy_shader(&shader_store.shader[entity]);
+    shader_store.shader[entity] = (R3_Shader){0};
+}
+
+u8 _get_shader3D_impl(u32 entity, R3_Shader* component) {
+    component = &shader_store.shader[entity];
+    return LIBX_TRUE;
+}
+
+
+u8 _r3_register_component3D(_r3_3D_api* r3_3D) {
+    if (!r3_3D) return LIBX_FALSE;    // error: null ptr!
+
+    identity =  mathx->mat.identity4();
+
+    if (!ecsx->register_component(R3_MESH3D, &mesh_store, _add_mesh3D_impl, _rem_mesh3D_impl, (COMPONENT_GET_FPTR)_get_mesh3D_impl)) {
+        printf("failed to register R3_Mesh3D component!\n");
+        return LIBX_FALSE;
+    }
+    
+    if (!ecsx->register_component(R3_TRANSFORM3D, &transform_store, _add_transform3D_impl, _rem_transform3D_impl, (COMPONENT_GET_FPTR)_get_transform3D_impl)) {
+        printf("failed to register R3_Transform3D component!\n");
+        return LIBX_FALSE;
+    }
+    
+    if (!ecsx->register_component(R3_MATERIAL3D, &material_store, _add_material3D_impl, _rem_material3D_impl, (COMPONENT_GET_FPTR)_get_material3D_impl)) {
+        printf("failed to register R3_Material3D component!\n");
+        return LIBX_FALSE;
+    }
+    
+    if (!ecsx->register_component(R3_SHADER3D, &shader_store, _add_shader3D_impl, _rem_shader3D_impl, (COMPONENT_GET_FPTR)_get_shader3D_impl)) {
+        printf("failed to register R3_Shader component!\n");
+        return LIBX_FALSE;
+    }
+    
+    if (!ecsx->register_system(R3_MESH3D, "render3D", _mesh3D_system_impl)) {
+        printf("failed to register R3_Mesh3D component systems!\n");
+        return LIBX_FALSE;
+    }
+    
+    if (!ecsx->register_system(R3_TRANSFORM3D, "transform3D", _transform3D_system_impl)) {
+        printf("failed to register R3_Transform3D component systems!\n");
+        return LIBX_FALSE;
+    }
+    
+    if (!ecsx->register_system(R3_MATERIAL3D, "material3D", _material3D_system_impl)) {
+        printf("failed to register R3_Material3D component systems!\n");
+        return LIBX_FALSE;
+    }
+
+    r3_3D->set_shader3D = _set_shader3D_impl;
+
+    return LIBX_TRUE;
+}
+
+u8 _r3_unregister_component3D(void) {
+    LIBX_FORI(0, R3_COMPONENT3D_COUNT, 1) {
+        if (!ecsx->unregister_systems(i)) return LIBX_FALSE;
+        if (!ecsx->unregister_component(i)) return LIBX_FALSE;
+    }
+
+    return LIBX_TRUE;
+}

--- a/r3/r3.3D/src/r3.3D.c
+++ b/r3/r3.3D/src/r3.3D.c
@@ -1,0 +1,27 @@
+#include <r3/r3.3D/include/r3.3D.h>
+
+_r3_3D_api* r3_3D = NULL;
+_r3_core_api* core_3D = NULL;
+
+u8 r3_init_3D(void) {
+    if (r3_3D != NULL) return LIBX_TRUE;  // redundant call: 3D api initialized!
+
+    r3_3D = memx->alloc(sizeof(_r3_3D_api), 8);
+    if (!r3_3D) return LIBX_FALSE;  // error: failed to allocate 3D api! out of memory!
+
+    if (!_r3_init_shape3D(r3_3D)) return LIBX_FALSE;    // error: failed to init shape3D api!
+    
+    if (!_r3_register_component3D(r3_3D)) return LIBX_FALSE;    // error: failed to register 3D components!
+
+    return LIBX_TRUE;
+}
+
+u8 r3_cleanup_3D(void) {
+    if (!r3_3D || !core_3D) return LIBX_TRUE;  // redumdamt call: 3D api not initialized!
+
+    u8 result = LIBX_TRUE;
+    if (!_r3_unregister_component3D()) result = LIBX_FALSE;    // error: failed to unregister 3D components!
+
+    memx->dealloc(r3_3D);
+    return result;
+}

--- a/r3/r3.3D/src/shape3D.c
+++ b/r3/r3.3D/src/shape3D.c
@@ -1,0 +1,78 @@
+#include <r3/r3.3D/include/r3.3D.h>
+
+R3_Vertex_Data _cube3D_impl(Vec3 size, Vec3 color) {
+    f32 half_width  = (size.x / 100.0) / 2.0f;
+    f32 half_height = (size.y / 100.0) / 2.0f;
+    f32 half_depth  = (size.z / 100.0) / 2.0f;
+
+    f32 vertices[] = {
+        // Back face (-Z normal)
+        -half_width, -half_height, -half_depth,  color.x, color.y, color.z,  0.0f, 0.0f,  0.0f,  0.0f, -1.0f,
+         half_width, -half_height, -half_depth,  color.x, color.y, color.z,  1.0f, 0.0f,  0.0f,  0.0f, -1.0f,
+         half_width,  half_height, -half_depth,  color.x, color.y, color.z,  1.0f, 1.0f,  0.0f,  0.0f, -1.0f,
+        -half_width,  half_height, -half_depth,  color.x, color.y, color.z,  0.0f, 1.0f,  0.0f,  0.0f, -1.0f,
+    
+        // Front face (+Z normal)
+        -half_width, -half_height,  half_depth,  color.x, color.y, color.z,  0.0f, 0.0f,  0.0f,  0.0f,  1.0f,
+         half_width, -half_height,  half_depth,  color.x, color.y, color.z,  1.0f, 0.0f,  0.0f,  0.0f,  1.0f,
+         half_width,  half_height,  half_depth,  color.x, color.y, color.z,  1.0f, 1.0f,  0.0f,  0.0f,  1.0f,
+        -half_width,  half_height,  half_depth,  color.x, color.y, color.z,  0.0f, 1.0f,  0.0f,  0.0f,  1.0f,
+    
+        // Left face (-X normal)
+        -half_width, -half_height,  half_depth,  color.x, color.y, color.z,  1.0f, 0.0f, -1.0f,  0.0f,  0.0f,
+        -half_width, -half_height, -half_depth,  color.x, color.y, color.z,  0.0f, 0.0f, -1.0f,  0.0f,  0.0f,
+        -half_width,  half_height, -half_depth,  color.x, color.y, color.z,  0.0f, 1.0f, -1.0f,  0.0f,  0.0f,
+        -half_width,  half_height,  half_depth,  color.x, color.y, color.z,  1.0f, 1.0f, -1.0f,  0.0f,  0.0f,
+    
+        // Right face (+X normal)
+         half_width, -half_height,  half_depth,  color.x, color.y, color.z,  0.0f, 0.0f,  1.0f,  0.0f,  0.0f,
+         half_width, -half_height, -half_depth,  color.x, color.y, color.z,  1.0f, 0.0f,  1.0f,  0.0f,  0.0f,
+         half_width,  half_height, -half_depth,  color.x, color.y, color.z,  1.0f, 1.0f,  1.0f,  0.0f,  0.0f,
+         half_width,  half_height,  half_depth,  color.x, color.y, color.z,  0.0f, 1.0f,  1.0f,  0.0f,  0.0f,
+    
+        // Bottom face (-Y normal)
+        -half_width, -half_height, -half_depth,  color.x, color.y, color.z,  0.0f, 1.0f,  0.0f, -1.0f,  0.0f,
+         half_width, -half_height, -half_depth,  color.x, color.y, color.z,  1.0f, 1.0f,  0.0f, -1.0f,  0.0f,
+         half_width, -half_height,  half_depth,  color.x, color.y, color.z,  1.0f, 0.0f,  0.0f, -1.0f,  0.0f,
+        -half_width, -half_height,  half_depth,  color.x, color.y, color.z,  0.0f, 0.0f,  0.0f, -1.0f,  0.0f,
+    
+        // Top face (+Y normal)
+        -half_width,  half_height, -half_depth,  color.x, color.y, color.z,  0.0f, 1.0f,  0.0f,  1.0f,  0.0f,
+         half_width,  half_height, -half_depth,  color.x, color.y, color.z,  1.0f, 1.0f,  0.0f,  1.0f,  0.0f,
+         half_width,  half_height,  half_depth,  color.x, color.y, color.z,  1.0f, 0.0f,  0.0f,  1.0f,  0.0f,
+        -half_width,  half_height,  half_depth,  color.x, color.y, color.z,  0.0f, 0.0f,  0.0f,  1.0f,  0.0f,
+    };
+
+    u32 indices[] = {
+        // Back face
+        0, 1, 2, 2, 3, 0,
+        // Front face
+        4, 5, 6, 6, 7, 4,
+        // Left face
+        8, 9, 10, 10, 11, 8,
+        // Right face
+        12, 13, 14, 14, 15, 12,
+        // Bottom face
+        16, 17, 18, 18, 19, 16,
+        // Top face
+        20, 21, 22, 22, 23, 20
+    };
+
+    return r3_core->graphics.create_vertex_data(
+        vertices, 24,
+        indices, 36,
+        R3_LOCATION_ATTR | R3_COLOR_ATTR | R3_TCOORD_ATTR | R3_NORMAL_ATTR
+    );
+}
+
+
+u8 _r3_init_shape3D(_r3_3D_api* r3_3D) {
+    if (!r3_3D) return LIBX_FALSE;  // error: null ptr!
+    
+    if (r3_3D->shape3D.cube3D != NULL
+    ) return LIBX_TRUE; // error: reduntant call: shape3D api initialized!
+
+    r3_3D->shape3D.cube3D = _cube3D_impl;
+
+    return LIBX_TRUE;
+}

--- a/r3/r3.core/include/r3.core.h
+++ b/r3/r3.core/include/r3.core.h
@@ -29,6 +29,9 @@ u8 r3_cleanup_core(void);
     #if ((R3_MODULES & R3_2D))
         #include <r3/r3.2D/include/r3.2D.h>
     #endif
+    #if ((R3_MODULES & R3_3D))
+        #include <r3/r3.3D/include/r3.3D.h>
+    #endif
 #else
     #define R3_MODULES R3_CORE
 #endif

--- a/r3/r3.core/src/r3.core.c
+++ b/r3/r3.core/src/r3.core.c
@@ -1,6 +1,7 @@
 #include <r3/r3.core/include/r3.core.h>
 #include <r3/r3.pack/include/r3.pack.h>
 #include <r3/r3.2D/include/r3.2D.h>
+#include <r3/r3.3D/include/r3.3D.h>
 
 _r3_core_api* r3_core = NULL;
 
@@ -31,6 +32,11 @@ u8 r3_init_core(u8 modules) {
         if (!r3_init_2D()) return LIBX_FALSE;    // error: failed to init 2D api!
     }
 
+    if ((modules & R3_3D) == R3_3D) {
+        if (!libx_init_ecs()) return LIBX_FALSE;        // error: failed to init ecs api!
+        if (!r3_init_3D()) return LIBX_FALSE;    // error: failed to init 3D api!
+    }
+
     r3_core->modules = modules;
     return LIBX_TRUE;
 }
@@ -53,6 +59,11 @@ u8 r3_cleanup_core(void) {
 
     if ((r3_core->modules & R3_2D) == R3_2D) {
         result = r3_cleanup_2D();
+        libx_cleanup_ecs();
+    }
+    
+    if ((r3_core->modules & R3_3D) == R3_3D) {
+        result = r3_cleanup_3D();
         libx_cleanup_ecs();
     }
     

--- a/r3/r3.core/src/r3.graphics.c
+++ b/r3/r3.core/src/r3.graphics.c
@@ -252,10 +252,8 @@ void _flush_pipeline_impl(void) {
         if (call.shader) {
             if (shader) {
                 if (shader->program != call.shader->program) shader = call.shader;
-            } else shader = call.shader;
-        } else {
-            if (!shader) continue;
-        }
+            }
+        } if (!shader) continue;  // error: no global shader set!
         
         if (call.model) _graphics_api->set_uniform(shader,
             &(R3_Uniform){

--- a/r3/r3.core/src/r3.graphics.c
+++ b/r3/r3.core/src/r3.graphics.c
@@ -284,7 +284,7 @@ void _flush_pipeline_impl(void) {
             .value = &_graphics_api->pipeline.proj.m
         });
         
-        if (call.uniform_count && call.uniform_count <= 12) {
+        if (call.uniform_count && call.uniform_count <= (16 - shader->uniforms->meta.count)) {
             LIBX_FORI(0, call.uniform_count, 1) {
                 if (!call.uniforms[i].name || !call.uniforms[i].value) break;
                 _graphics_api->set_uniform(shader, &call.uniforms[i]);

--- a/r3make
+++ b/r3make
@@ -8,7 +8,7 @@
                 }
             },
             "c-defines": ["DLL_EXPORT"],
-	        "src-dirs": ["r3/r3.core/src", "r3/r3.pack/src", "r3/r3.2D/src"],
+	        "src-dirs": ["r3/r3.core/src", "r3/r3.pack/src", "r3/r3.2D/src", "r3/r3.3D/src"],
             "inc-dirs": [".", "external"],
             "lib-links": {
                 "gdi32": null,


### PR DESCRIPTION
## What's Changed
- modules:
    - r3.core
    - r3.3D

- implemented enumerations:
    - `R3_Component3D` for housing 3D component IDs

- implemented structures:
    - `R3_Mesh3D` storing pointers to component data
    - `R3_Transform3D` storing pointers to component data
    - `R3_Material3D` storing pointers to component data

- implemented functions:
    - `_add_mesh3D_impl()`
    - `_rem_mesh3D_impl()`
    - `_get_mesh3D_impl()`
    - `_mesh3D_system_impl()`
    <br>

    - `_add_transform3D_impl()`
    - `_rem_transform3D_impl()`
    - `_get_transform3D_impl()`
    - `_transform_system_impl()`
    <br>

    - `_add_material3D_impl()`
    - `_rem_material3D_impl()`
    - `_get_material3D_impl()`
    - `_material3D_system_impl()`
    <br>

    - `_add_shader3D_impl()`
    - `_rem_shader3D_impl()`
    - `_get_shader3D_impl()`
    - `_set_shader3D_impl()`
